### PR TITLE
unpack() crash fix

### DIFF
--- a/src/php/classes/class_APNS.php
+++ b/src/php/classes/class_APNS.php
@@ -581,7 +581,9 @@ class APNS {
 				else if($numChanged>0) {
 					$command = ord(fread($fp, 1));
 					$status = ord(fread($fp, 1));
-					$identifier = implode('', unpack("N", fread($fp, 4)));
+					$identifier = "";
+					$identifierBinary = fread($fp, 4);
+					if(strlen($identifierBinary)==4) $identifier = implode('', unpack("N", $identifierBinary));
 					$statusDesc = array(
 						0 => 'No errors encountered',
 						1 => 'Processing error',


### PR DESCRIPTION
In some cases APNS may return no data. (for any reason $numChanged = 1 but $r is still empty, maybe the TLS protocol is a reason)
unpack() will crash if $fp is empty.

Message will be "APNS responded with command(0) status(0) pid()."