### PR TITLE
Errors in error handler

### DIFF
--- a/src/php/classes/class_APNS.php
+++ b/src/php/classes/class_APNS.php
@@ -692,6 +692,9 @@ class APNS {
 		$error .= "\n";
 		$i=1;
 		foreach($backtrace as $errorcode){
+			$file = (isset($errorcode['file']) ? $errorcode['file'] : "");
+		        $class = (isset($errorcode['class']) ? $errorcode['class'] : "");
+		        $function = (isset($errorcode['function']) ? $errorcode['function'] : "");
 			$file = ($errorcode['file']!='') ? "-> File: ".basename($errorcode['file'])." (line ".$errorcode['line'].")":"";
 			$error .= "\n\t".$i.") ".$errorcode['class']."::".$errorcode['function']." {$file}";
 			$i++;


### PR DESCRIPTION
I had notices of this kind because of undefined index :
<b>Notice</b>:  Undefined index: class in <b>/home/.../easyapns/src/php/classes/class_APNS.php</b> on line <b>696</b><br />
<b>Notice</b>:  Undefined index: file in <b>/home/.../easyapns/src/php/classes/class_APNS.php</b> on line <b>695</b><br />